### PR TITLE
Add support for more complex types

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ Originally based off of [deep-clone-derive](https://github.com/asajeffrey/deep-c
  * normal [structs](./tests/struct.rs)
  * enums with tuple variants [tuple enums](./tests/simple_enum.rs)
  * `IntoOwned` alike fields (actually assumes all fields with types with lifetimes are `IntoOwned` alike)
- * [options of Cow or Cow-like types](./tests/opt_field.rs) `Option<Cow<'a, str>>` and `Option<Foo<'a>>`
- * [vectors of Cow or Cow-like types](./tests/vec.rs)
+ * `Cow<'a, B>`
+ * [`Option<T>`](./tests/opt_field.rs)
+ * [`Vec<T>`](./tests/vec.rs)
+ * `Box<T>`
+ * [arrays](./tests/array.rs)
+ * [tuples](./tests/tuple.rs)
+ * arbitrarily nested types built from the above ([Example 1](./tests/nested_types.rs), [Example 2](./tests/triple_cow.rs))
 
 But wait there is even more! `[derive(Borrowed)]` generates a currently perhaps a bit limited version of a method like:
 
@@ -59,9 +64,7 @@ Note, there's no trait implementation expected because I didn't find one at the 
 Currently deriving will fail miserably for at least but not limited to:
 
  * `IntoOwned`: borrowed fields like `&'a str`
- * `Borrowed`: struct/enum has more than one lifetime
- * both: arrays not supported
- * both: into_owned/borrowed types inside tuples inside vectors
+ * `Borrowed`: struct/enum has multiple lifetimes that depend on each other (explicitly or implicitly)
 
 Using with incompatible types results in not so understandable error messages. For example, given a struct:
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,6 @@
 use crate::field_kind::FieldKind;
 
-pub fn has_lifetime_arguments(segments: &[syn::PathSegment]) -> bool {
+pub fn has_lifetime_arguments(segments: &[&syn::PathSegment]) -> bool {
     if let Some(syn::PathArguments::AngleBracketed(generics)) =
         segments.last().map(|x| &x.arguments)
     {
@@ -13,36 +13,7 @@ pub fn has_lifetime_arguments(segments: &[syn::PathSegment]) -> bool {
     }
 }
 
-pub fn number_of_type_arguments(segments: &[syn::PathSegment]) -> usize {
-    if let Some(syn::PathArguments::AngleBracketed(generics)) =
-        segments.last().map(|x| &x.arguments)
-    {
-        generics
-            .args
-            .iter()
-            .filter(|f| matches!(f, syn::GenericArgument::Type(_)))
-            .count()
-    } else {
-        0
-    }
-}
-
-pub fn has_binding_arguments(segments: &[syn::PathSegment]) -> bool {
-    if let Some(syn::PathArguments::AngleBracketed(generics)) =
-        segments.last().map(|x| &x.arguments)
-    {
-        generics.args.iter().any(|f| {
-            matches!(
-                f,
-                syn::GenericArgument::AssocConst(_) | syn::GenericArgument::AssocType(_)
-            )
-        })
-    } else {
-        false
-    }
-}
-
-fn type_hopefully_is(segments: &[syn::PathSegment], expected: &str) -> bool {
+fn type_hopefully_is(segments: &[&syn::PathSegment], expected: &str) -> bool {
     let expected = expected
         .split("::")
         .map(|x| quote::format_ident!("{}", x))
@@ -63,106 +34,65 @@ fn type_hopefully_is(segments: &[syn::PathSegment], expected: &str) -> bool {
     false
 }
 
-pub fn is_cow(segments: &[syn::PathSegment]) -> bool {
-    type_hopefully_is(segments, "std::borrow::Cow")
-}
-
-pub fn is_cow_alike(segments: &[syn::PathSegment]) -> bool {
-    if let Some(syn::PathArguments::AngleBracketed(_data)) = segments.last().map(|x| &x.arguments) {
-        has_lifetime_arguments(segments)
-    } else {
-        false
-    }
-}
-
-pub fn collect_segments(path: &syn::Path) -> Vec<syn::PathSegment> {
-    path.segments.iter().cloned().collect::<Vec<_>>()
-}
-
-pub fn is_opt_cow(mut segments: Vec<syn::PathSegment>) -> Option<FieldKind> {
-    let mut levels = 0;
-    loop {
-        if type_hopefully_is(&segments, "std::option::Option") {
-            if let syn::PathSegment {
-                arguments: syn::PathArguments::AngleBracketed(ref data),
-                ..
-            } = *segments.last().expect("last segment")
-            {
-                if has_lifetime_arguments(&segments) || has_binding_arguments(&segments) {
-                    // Option<&'a ?> cannot be moved but let the compiler complain
-                    // don't know about data bindings
-                    break;
-                }
-
-                if number_of_type_arguments(&segments) != 1 {
-                    // Option<A, B> probably means some other, movable option
-                    break;
-                }
-
-                match *data.args.first().expect("first arg") {
-                    syn::GenericArgument::Type(syn::Type::Path(syn::TypePath {
-                        // segments: ref next_segments,
-                        ref path,
-                        ..
-                    })) => {
-                        levels += 1;
-                        segments = collect_segments(path);
-                        continue;
-                    }
-                    _ => break,
-                }
-            }
-        } else if is_cow(&segments) {
-            return Some(FieldKind::OptField(levels, Box::new(FieldKind::PlainCow)));
-        } else if is_cow_alike(&segments) {
-            return Some(FieldKind::OptField(levels, Box::new(FieldKind::AssumedCow)));
-        }
-
-        break;
+pub fn cow_field(segments: &[&syn::PathSegment]) -> Option<FieldKind> {
+    if !type_hopefully_is(segments, "std::borrow::Cow") {
+        return None;
     }
 
-    None
+    let syn::PathSegment {
+        arguments: syn::PathArguments::AngleBracketed(data),
+        ..
+    } = segments.last().expect("last segment")
+    else {
+        return None;
+    };
+
+    if data.args.len() != 2 {
+        return None;
+    }
+    let syn::GenericArgument::Lifetime(_) = &data.args[0] else {
+        return None;
+    };
+    let syn::GenericArgument::Type(arg_type) = &data.args[1] else {
+        return None;
+    };
+
+    Some(FieldKind::resolve(arg_type))
 }
 
-pub fn is_iter_field(mut segments: Vec<syn::PathSegment>) -> Option<FieldKind> {
-    loop {
-        // this should be easy to do for arrays as well..
-        if type_hopefully_is(&segments, "std::vec::Vec") {
-            if let syn::PathSegment {
-                arguments: syn::PathArguments::AngleBracketed(ref data),
-                ..
-            } = *segments.last().expect("last segment")
-            {
-                if has_lifetime_arguments(&segments) || has_binding_arguments(&segments) {
-                    break;
-                }
+pub fn is_cow_alike(segments: &[&syn::PathSegment]) -> bool {
+    matches!(
+        segments.last().map(|x| &x.arguments),
+        Some(syn::PathArguments::AngleBracketed(_))
+    ) && has_lifetime_arguments(segments)
+}
 
-                // if data.types.len() != 1 {
-                if number_of_type_arguments(&segments) != 1 {
-                    // TODO: this could be something like Vec<(u32, Bar<'a>)>?
-                    break;
-                }
+pub fn collect_segments(path: &syn::Path) -> Vec<&syn::PathSegment> {
+    path.segments.iter().collect::<Vec<_>>()
+}
 
-                match *data.args.first().expect("first arg") {
-                    syn::GenericArgument::Type(syn::Type::Path(syn::TypePath {
-                        // segments: ref next_segments,
-                        ref path,
-                        ..
-                    })) => {
-                        segments = collect_segments(path);
-                        continue;
-                    }
-                    _ => break,
-                }
-            }
-        } else if is_cow(&segments) {
-            return Some(FieldKind::IterableField(Box::new(FieldKind::PlainCow)));
-        } else if is_cow_alike(&segments) {
-            return Some(FieldKind::IterableField(Box::new(FieldKind::AssumedCow)));
-        }
-
-        break;
+/// Checks for a given type with a single generic type argument
+///
+/// Examples for such types are [Option<T>] and [Vec<T>].
+pub fn generic_field(segments: &[&syn::PathSegment], type_name: &str) -> Option<FieldKind> {
+    if !type_hopefully_is(segments, type_name) {
+        return None;
     }
 
-    None
+    let syn::PathSegment {
+        arguments: syn::PathArguments::AngleBracketed(data),
+        ..
+    } = segments.last().expect("last segment")
+    else {
+        return None;
+    };
+
+    if data.args.len() != 1 {
+        return None;
+    }
+    let syn::GenericArgument::Type(arg_type) = &data.args[0] else {
+        return None;
+    };
+
+    Some(FieldKind::resolve(arg_type))
 }

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate derive_into_owned;
+
+use std::borrow::Cow;
+
+#[derive(IntoOwned, Borrowed)]
+struct Array<'a> {
+    a: [Cow<'a, str>; 2],
+}
+
+#[test]
+fn array() {
+    let val = Array {
+        a: [Cow::Owned("str".to_owned()), Cow::Borrowed("str")],
+    };
+    let owned = val.into_owned();
+
+    test_static(&owned);
+
+    let borrowed = owned.borrowed();
+    // owned cannot be moved while borrowed exists
+    test_borrowed(&owned, borrowed);
+}
+
+fn test_static(_s: &Array<'static>) {}
+
+fn test_borrowed<'b, 'a: 'b>(lives_longer: &Array<'a>, lives_less: Array<'b>) {
+    drop(lives_less);
+    #[allow(dropping_references)]
+    drop(lives_longer);
+}

--- a/tests/many_fields.rs
+++ b/tests/many_fields.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate derive_into_owned;
+
+use std::borrow::Cow;
+
+#[allow(dead_code, clippy::redundant_allocation)]
+#[derive(IntoOwned, Borrowed)]
+struct TestTypes<'a> {
+    a: Box<Cow<'a, str>>,
+    b: Box<i32>,
+    c: Option<i32>,
+    d: Vec<i32>,
+    e: Option<Box<i32>>,
+    f: Option<Box<Box<i32>>>,
+    g: Box<Option<()>>,
+    h: String,
+    i: (String, String),
+    j: (),
+    k: Option<(i32, String)>,
+    l: Option<(i32, Vec<String>, Cow<'a, str>)>,
+    m: Box<(i32, String, Vec<Cow<'a, str>>)>,
+    n: Vec<(i32, Option<String>, Option<Cow<'a, str>>)>,
+    o: ((), ()),
+    p: (String, (String, (String, String))),
+    #[allow(clippy::type_complexity)]
+    q: (String, (String, (String, Box<Cow<'a, str>>))),
+}

--- a/tests/nested_types.rs
+++ b/tests/nested_types.rs
@@ -5,13 +5,14 @@ use std::borrow::Cow;
 
 #[derive(IntoOwned, Borrowed)]
 struct NestedTypes<'a> {
-    a: Vec<Option<Cow<'a, Option<Cow<'a, str>>>>>,
+    #[allow(clippy::type_complexity)]
+    a: Vec<Option<Cow<'a, Option<Box<Cow<'a, str>>>>>>,
 }
 
 #[test]
 fn triple_cow() {
     let val = NestedTypes {
-        a: vec![Some(Cow::Owned(Some(Cow::Borrowed("str"))))],
+        a: vec![Some(Cow::Owned(Some(Box::new(Cow::Borrowed("str")))))],
     };
     let owned = val.into_owned();
 

--- a/tests/nested_types.rs
+++ b/tests/nested_types.rs
@@ -1,0 +1,31 @@
+#[macro_use]
+extern crate derive_into_owned;
+
+use std::borrow::Cow;
+
+#[derive(IntoOwned, Borrowed)]
+struct NestedTypes<'a> {
+    a: Vec<Option<Cow<'a, Option<Cow<'a, str>>>>>,
+}
+
+#[test]
+fn triple_cow() {
+    let val = NestedTypes {
+        a: vec![Some(Cow::Owned(Some(Cow::Borrowed("str"))))],
+    };
+    let owned = val.into_owned();
+
+    test_static(&owned);
+
+    let borrowed = owned.borrowed();
+    // owned cannot be moved while borrowed exists
+    test_borrowed(&owned, borrowed);
+}
+
+fn test_static(_s: &NestedTypes<'static>) {}
+
+fn test_borrowed<'b, 'a: 'b>(lives_longer: &NestedTypes<'a>, lives_less: NestedTypes<'b>) {
+    drop(lives_less);
+    #[allow(dropping_references)]
+    drop(lives_longer);
+}

--- a/tests/recursive.rs
+++ b/tests/recursive.rs
@@ -1,0 +1,30 @@
+use std::borrow::Cow;
+
+#[macro_use]
+extern crate derive_into_owned;
+
+#[derive(IntoOwned, Borrowed)]
+enum Rec<'a> {
+    Rec(Option<Box<Rec<'a>>>),
+    Cow(Cow<'a, str>),
+}
+
+#[test]
+fn rec() {
+    let val = Rec::Rec(Some(Box::new(Rec::Cow(Cow::Borrowed("str")))));
+    let owned = val.into_owned();
+
+    test_static(&owned);
+
+    let borrowed = owned.borrowed();
+    // owned cannot be moved while borrowed exists
+    test_borrowed(&owned, borrowed);
+}
+
+fn test_static(_s: &Rec<'static>) {}
+
+fn test_borrowed<'b, 'a: 'b>(lives_longer: &Rec<'a>, lives_less: Rec<'b>) {
+    drop(lives_less);
+    #[allow(dropping_references)]
+    drop(lives_longer);
+}

--- a/tests/triple_cow.rs
+++ b/tests/triple_cow.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate derive_into_owned;
+
+use std::borrow::Cow;
+
+// Note: Borrowed currently can't be derived for a type with multiple dependent
+// lifetimes - there is no easy way to determine whether multiple lifetimes
+// on an inner type are used for separate fields, or nested like here. At the
+// moment, it is assumed that the lifetimes are indepentent.
+
+#[derive(IntoOwned)]
+struct TripleCow<'a, 'b, 'c> {
+    a: Cow<'a, Cow<'b, Cow<'c, str>>>,
+}
+
+#[test]
+fn triple_cow() {
+    let inner1 = Cow::Owned("str".to_owned());
+    let inner2 = Cow::Borrowed(&inner1);
+    let val = TripleCow {
+        a: Cow::Borrowed(&inner2),
+    };
+    let owned = val.into_owned();
+
+    test_static(&owned);
+}
+
+fn test_static(_s: &TripleCow<'static, 'static, 'static>) {}

--- a/tests/tuple.rs
+++ b/tests/tuple.rs
@@ -1,0 +1,33 @@
+#[macro_use]
+extern crate derive_into_owned;
+
+use std::borrow::Cow;
+
+#[derive(IntoOwned, Borrowed)]
+struct Tuple<'a, 'b, 'c> {
+    a: (Cow<'a, str>, Option<Cow<'b, str>>),
+    b: (Cow<'c, str>,),
+}
+
+#[test]
+fn tuple() {
+    let val = Tuple {
+        a: (Cow::Owned("str".to_owned()), None),
+        b: (Cow::Borrowed("str"),),
+    };
+    let owned = val.into_owned();
+
+    test_static(&owned);
+
+    let borrowed = owned.borrowed();
+    // owned cannot be moved while borrowed exists
+    test_borrowed(&owned, borrowed);
+}
+
+fn test_static(_s: &Tuple<'static, 'static, 'static>) {}
+
+fn test_borrowed<'b, 'a: 'b>(lives_longer: &Tuple<'a, 'a, 'a>, lives_less: Tuple<'b, 'b, 'b>) {
+    drop(lives_less);
+    #[allow(dropping_references)]
+    drop(lives_longer);
+}

--- a/tests/tuple_struct.rs
+++ b/tests/tuple_struct.rs
@@ -3,22 +3,21 @@
 #[macro_use]
 extern crate derive_into_owned;
 
-use std::borrow;
-use std::borrow::Cow;
+use std::borrow::{self, Cow};
 
-#[derive(IntoOwned)]
+#[derive(IntoOwned, Borrowed)]
 struct Foo<'a>(Cow<'a, str>);
 
-#[derive(IntoOwned)]
+#[derive(IntoOwned, Borrowed)]
 struct FooExtraFields<'a>(u32, Cow<'a, str>, bool, Vec<bool>);
 
-#[derive(IntoOwned)]
+#[derive(IntoOwned, Borrowed)]
 struct Bar<'a>(::std::borrow::Cow<'a, str>);
 
-#[derive(IntoOwned)]
+#[derive(IntoOwned, Borrowed)]
 struct Car<'a>(std::borrow::Cow<'a, str>);
 
-#[derive(IntoOwned)]
+#[derive(IntoOwned, Borrowed)]
 struct Dar<'a>(borrow::Cow<'a, str>);
 
 #[test]
@@ -26,10 +25,19 @@ fn tuple_struct() {
     let non_static_string: String = "foobar".to_string();
 
     let thing = Foo(Cow::Borrowed(&non_static_string));
+    let owned = thing.into_owned();
 
-    accepts_only_static(thing.into_owned());
+    accepts_only_static(&owned);
+
+    let borrowed = owned.borrowed();
+    // owned cannot be moved while borrowed exists
+    test_borrowed(&owned, borrowed);
 }
 
-fn accepts_only_static(static_foo: Foo<'static>) {
-    drop(static_foo);
+fn accepts_only_static(_static_foo: &Foo<'static>) {}
+
+fn test_borrowed<'b, 'a: 'b>(lives_longer: &Foo<'a>, lives_less: Foo<'b>) {
+    drop(lives_less);
+    #[allow(dropping_references)]
+    drop(lives_longer);
 }

--- a/tests/unit_struct.rs
+++ b/tests/unit_struct.rs
@@ -1,4 +1,7 @@
 #![allow(unused)]
 
-#[derive(derive_into_owned::IntoOwned)]
+#[macro_use]
+extern crate derive_into_owned;
+
+#[derive(IntoOwned, Borrowed)]
 struct Far;


### PR DESCRIPTION
This is a fairly large overhaul of the field type logic, adding support for various new types:

- arrays
- tuples
- `Box<T>`
- arbitrarily nested types built from all supported types

It also fixes deriving `Borrowed` for tuple structs, which was previously broken.

All existing tests pass without changes, and I've added new testcases for all new features.

Fixes #13